### PR TITLE
Workgroup html updates

### DIFF
--- a/MyHtml.md
+++ b/MyHtml.md
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+<body>
+<h1>Hello World</h1>
+<p>I'm hosted with GitHub Pages.</p>
+</body>
+</html>

--- a/MyHtml.md
+++ b/MyHtml.md
@@ -1,7 +1,0 @@
-<!DOCTYPE html>
-<html>
-<body>
-<h1>Hello World</h1>
-<p>I'm hosted with GitHub Pages.</p>
-</body>
-</html>

--- a/workgroups.html
+++ b/workgroups.html
@@ -144,7 +144,7 @@
                     <p>Join the mailing list <font color="#0000FF" size="3">sonic-test-workgroup@gmail.com </font></p>
 		    <p>&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&ensp; <font color="#0000FF" size="3">sonic-mgmt-workgroup@googlegroups.com </font></p>
 		    <p>&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&ensp; <font color="#0000FF" size="3">sonic-mlag-workgroup@googlegroups.com </font></p>
-		    <p>&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp; <font color="#0000FF" size="3">sonic-vrf-workgroup@googlegroups.com </font></p>
+		    <p>&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&ensp; <font color="#0000FF" size="3">sonic-vrf-workgroup@googlegroups.com </font></p>
                     <p> Workgroup <a href="https://groups.google.com/forum/#!forum/sonic-test-workgroup"><font color="#0000FF" size="3">link</font></a></p>	
 					<h4 style="color: #01BAFD; margin-top: 70px; font-weight: bold"> Testing Workgroup Charter</h4>
 					<p> 1. Testbed improvement. 

--- a/workgroups.html
+++ b/workgroups.html
@@ -3,7 +3,10 @@
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width, initial-scale=1">    
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.0/css/bootstrap.min.css">
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.4.1/jquery.min.js"></script>
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.4.0/js/bootstrap.min.js"></script>
     <title>SONiC | Home</title>
 
     <!-- Favicon -->
@@ -137,52 +140,77 @@
   <!-- Start More Videos -->
   <section id="mu-about-us">
     <div class="container">
-        <div class="col-md-12">
+        <div class="col-lg-12 col-md-12">
 			<div class="row">
 			  <div class="col-lg-6 col-md-6">				
 				  <h3 style="color: #01BAFD; margin-top: 70px; font-weight: bold"> Testing Workgroup</h3>
-                    <p>Join the mailing list <font color="#0000FF" size="3">sonic-test-workgroup@gmail.com </font></p>
-		    <p>&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&ensp; <font color="#0000FF" size="3">sonic-mgmt-workgroup@googlegroups.com </font></p>
-		    <p>&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&ensp; <font color="#0000FF" size="3">sonic-mlag-workgroup@googlegroups.com </font></p>
-		    <p>&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&ensp; <font color="#0000FF" size="3">sonic-vrf-workgroup@googlegroups.com </font></p>
-                    <p> Workgroup <a href="https://groups.google.com/forum/#!forum/sonic-test-workgroup"><font color="#0000FF" size="3">link</font></a></p>	
-					<h4 style="color: #01BAFD; margin-top: 70px; font-weight: bold"> Testing Workgroup Charter</h4>
-					<p> 1. Testbed improvement. 
+				  <p> Join the mailing list <font color="#0000FF" size="3">sonic-test-workgroup@gmail.com </font></p>
+                    		  <p> Workgroup <a href="https://groups.google.com/forum/#!forum/sonic-test-workgroup"><font color="#0000FF" size="3">link</font></a></p>
+	            
+					<h4 style="color: #01BAFD; margin-top: 20px; font-weight: bold"> Testing Workgroup Charter</h4></p>
+					<p> 
+				  	   <ol>
+				  	       <li>Testbed improvement.</li>
+					       <li>Pytest framework enhancement </li>
+					       <li>Pytest conversion from ansible test. </li>
+					       <li>Specific/new tests </li>
+					       <li>Visualized DUT with data plane capabilities </li>
+					       <li>One(AKA, Crystalnet) integration (open source) </li>
+				  	   </ol>
+				  			  
+				               For detailed SONiC test-workgroup charter click <a href="https://groups.google.com/forum/#!topic/sonic-test-workgroup/OD_UhjqlZ9Y"><font color="0000FF" size="3">here</font></a>.
+				  </p>
+				  
+				  <h3 style="color: #01BAFD; margin-top: 70px; font-weight: bold"> VRF Workgroup</h3>
+                    		  <p>Join the mailing list <font color="#0000FF" size="3">sonic-vrf-workgroup@googlegroups.com </font></p>
+                    		  <p> Workgroup <a href="https://groups.google.com/forum/#!forum/sonic-vrf-workgroup"><font color="#0000FF" size="3">vrf-link</font></a></p>
+	            
+					<h4 style="color: #01BAFD; margin-top: 20px; font-weight: bold"> VRF Workgroup Charter</h4>
+			               	<p> 1. SONiC VRF enhancement 
 						<ul style="list-style-type:disc;padding-left: 30px;">
-						  <li> support sonic device as a neighbor. </li>
-						  <li> include pdu/console information.  </li>
-						  <li> using exabgp to build bgp routes.  </li>
+						  <li> VRF HLD 1.1 PR review, timeline. </li>
+						  <li> VRF CLI reconciliation.  </li>
+						  <li> Nephos test script availability.  </li>
+						  <li> Config DB migrator fix. </li>
 						</ul>
-
-						2. Pytest framework enhancement 
-						<ul style="list-style-type:disc;padding-left: 30px;">
-						   <li> How to execute commands on arista devices? </li>
-						   <li> How to improve the DUT reboot? Add console connection support so that we can see the console log while rebooting. </li>
-						   <li> Loganalyzer improvement can be implemented as a pytest fixture now. </li>
-						</ul>
-						3. Pytest conversion from ansible test. 
-						<ul style="list-style-type:disc;padding-left: 30px;">
-						   <li> strategy to conversion and deprecating the existing ansible test one-by-one. once a pytest has been developed, then we can deprecate the ansible test by calling the pytest in ansible playbook so that there is no change on the user side. Meanwhile, if there will be further improvement the improvement will go to pytest, and community does not need to maintain both versions. </li>
-						</ul>
-						4. Specific/new tests: 
-						<ul style="list-style-type:disc;padding-left: 30px;">
-						   <li> Platform related tests. () </li>
-						   <li> Qos/RDMA tests. </li>
-						   <li> image upgrades testing. </li>
-						   <li> acl tests improvement. </li>
-						   <li> scalability tests on all the tables (l3/acl/fdb), error handling. for example, l3 route exceeds the asic capability. </li>
-						   <li> validation checks, error scenario. for example, port-channel configuration sequence. </li>
-						   <li> scenario, flap the link while sending the traffic. </li>
-						   <li> test categorization: functional/scalability/negative tests/control plane performance/stress </li>
-						   <li> test creation based on current outstanding issues (prevent regression) </li>
-						</ul>
-						5. Visualized DUT with data plane capabilities 
-						<ul style="list-style-type:disc;padding-left: 30px;">
-						   <li> adding specific data plane functions to the virtual switch. </li>
-						</ul>
-						6. One(AKA, Crystalnet) integration (open source) 
 					</p>
-			  </div>					  
+		
+					<p><b>Note:</b> This group will converge soon with SONiC main community group.</p>
+		
+			  </div>
+			  <div class="col-lg-6 col-md-6">
+				  <h3 style="color: #01BAFD; margin-top: 70px; font-weight: bold"> Management Workgroup</h3>
+                    		  <p>Join the mailing list <font color="#0000FF" size="3">sonic-mgmt-workgroup@googlegroups.com </font></p>
+                    		  <p> Workgroup <a href="https://groups.google.com/forum/#!forum/sonic-mgmt-workgroup"><font color="#0000FF" size="3">mgmt-link</font></a></p>
+	            
+					<h4 style="color: #01BAFD; margin-top: 20px; font-weight: bold"> Management Workgroup Charter</h4>
+			               	<p> 
+					   <ol>
+					       <li> Simplify and Standardize SONiC management </li>
+					       <li> Make SONiC management DevOps friendly </li>
+					       <li> Industry standard CLI for SONiC config validations and error feedback </li>
+				  	   </ol>
+					</p>
+	  			   <br>
+	  			   <br>
+	  			   <br>
+	  			   <br>
+	  			   		
+				  <h3 style="color: #01BAFD; margin-top: 70px; font-weight: bold"> MLAG Workgroup</h3>
+                    		  <p>Join the mailing list <font color="#0000FF" size="3">sonic-mlag-workgroup@googlegroups.com </font></p>
+                    		  <p> Workgroup <a href="https://groups.google.com/forum/#!forum/sonic-mlag-workgroup"><font color="#0000FF" size="3">mlag-link</font></a>
+	            
+					<h4 style="color: #01BAFD; margin-top: 20px; font-weight: bold"> MLAG Workgroup Charter</h4></p>
+			               	<p> 
+					   <ol>
+					       <li> To provide user options to choose different version of MLAG to implement in the network. </li>
+					       <li> Co-existence of Nephos & BRCM in SONiC code base and letting the user to choose as per their requirement. </li>
+					       <li> To enable cross-functional collaboration by incorporating differet MLAG control plane frameworks. </li>
+	    				   </ol>	    				
+					</p>
+	  				
+	  				<p><b>Note:</b> This group will converge soon with SONiC main community group.</p>				  
+			  </div>       
             </div>
         </div>
     </div>

--- a/workgroups.html
+++ b/workgroups.html
@@ -144,7 +144,7 @@
                     <p>Join the mailing list <font color="#0000FF" size="3">sonic-test-workgroup@gmail.com </font></p>
 		    <p>&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&ensp; <font color="#0000FF" size="3">sonic-mgmt-workgroup@googlegroups.com </font></p>
 		    <p>&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&ensp; <font color="#0000FF" size="3">sonic-mlag-workgroup@googlegroups.com </font></p>
-		    <p>&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&ensp; <font color="#0000FF" size="3">sonic-vrf-workgroup@googlegroups.com </font></p>
+		    <p>&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp;&emsp; <font color="#0000FF" size="3">sonic-vrf-workgroup@googlegroups.com </font></p>
                     <p> Workgroup <a href="https://groups.google.com/forum/#!forum/sonic-test-workgroup"><font color="#0000FF" size="3">link</font></a></p>	
 					<h4 style="color: #01BAFD; margin-top: 70px; font-weight: bold"> Testing Workgroup Charter</h4>
 					<p> 1. Testbed improvement. 


### PR DESCRIPTION
1. Sonic management workgroup, MLAG workgroup & VRF workgroups added.
2. Notes for MLAG & VRF workgroups added
3. Sub points from Sonic testing workgroup removed and a link included for its reference.
4. Top margin space for the h3 headers reduced to 20px from 30px.
